### PR TITLE
Not intended to merge: macro invocation contents

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "tree-sitter-rust"
-description = "Rust grammar for the tree-sitter parsing library"
-version = "0.20.3"
+name = "tree_sitter_grep_tree-sitter-rust"
+description = "(forked version used internally by tree-sitter-grep) Rust grammar for the tree-sitter parsing library"
+version = "0.20.3-dev.0"
 authors = ["Max Brunsfeld <maxbrunsfeld@gmail.com>"]
 license = "MIT"
 readme = "bindings/rust/README.md"

--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -123,7 +123,7 @@ fn accumulate(self) -> Machine<{State::Accumulate}> {}
       (expression_statement
         (macro_invocation
           macro: (identifier)
-          (macro_invocation_contents
+          (expressions
             (string_literal)
             (identifier))))))
   (function_item
@@ -1112,7 +1112,7 @@ fn baz() {}
       (identifier)
       (macro_invocation
         (identifier)
-        (macro_invocation_contents
+        (expressions
           (string_literal)))))
   (function_item
     (identifier)
@@ -1587,8 +1587,7 @@ pub trait A: B + C + D {
       (type_identifier))
     (declaration_list
       (macro_invocation
-        (identifier)
-        (macro_invocation_contents))
+        (identifier))
       (function_signature_item
         (identifier)
         (parameters

--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -123,7 +123,7 @@ fn accumulate(self) -> Machine<{State::Accumulate}> {}
       (expression_statement
         (macro_invocation
           macro: (identifier)
-          (token_tree
+          (macro_invocation_contents
             (string_literal)
             (identifier))))))
   (function_item
@@ -1112,7 +1112,7 @@ fn baz() {}
       (identifier)
       (macro_invocation
         (identifier)
-        (token_tree
+        (macro_invocation_contents
           (string_literal)))))
   (function_item
     (identifier)
@@ -1588,7 +1588,7 @@ pub trait A: B + C + D {
     (declaration_list
       (macro_invocation
         (identifier)
-        (token_tree))
+        (macro_invocation_contents))
       (function_signature_item
         (identifier)
         (parameters

--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -1587,7 +1587,8 @@ pub trait A: B + C + D {
       (type_identifier))
     (declaration_list
       (macro_invocation
-        (identifier))
+        (identifier)
+        (token_tree))
       (function_signature_item
         (identifier)
         (parameters

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -721,7 +721,7 @@ let msg = match x {
           pattern: (match_pattern
             (macro_invocation
               macro: (identifier)
-              (token_tree
+              (macro_invocation_contents
                 (integer_literal))))
           value: (string_literal))
         (match_arm
@@ -1077,7 +1077,7 @@ Scoped functions with macros as types
         (bracketed_type
           (macro_invocation
             (identifier)
-            (token_tree)))
+            (macro_invocation_contents)))
         (identifier))
       (arguments))))
 

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1076,7 +1076,8 @@ Scoped functions with macros as types
       (scoped_identifier
         (bracketed_type
           (macro_invocation
-            (identifier)))
+            (identifier)
+            (expressions)))
         (identifier))
       (arguments))))
 

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -721,7 +721,7 @@ let msg = match x {
           pattern: (match_pattern
             (macro_invocation
               macro: (identifier)
-              (macro_invocation_contents
+              (expressions
                 (integer_literal))))
           value: (string_literal))
         (match_arm
@@ -1076,8 +1076,7 @@ Scoped functions with macros as types
       (scoped_identifier
         (bracketed_type
           (macro_invocation
-            (identifier)
-            (macro_invocation_contents)))
+            (identifier)))
         (identifier))
       (arguments))))
 

--- a/corpus/macros.txt
+++ b/corpus/macros.txt
@@ -13,25 +13,30 @@ f::g::h!{};
 (source_file
   (expression_statement
     (macro_invocation
-      (identifier)))
+      (identifier)
+      (expressions)))
   (expression_statement
     (macro_invocation
-      (identifier)))
+      (identifier)
+      (expressions)))
   (expression_statement
     (macro_invocation
-      (identifier)))
+      (identifier)
+      (token_tree)))
   (expression_statement
     (macro_invocation
       (scoped_identifier
         (identifier)
-        (identifier))))
+        (identifier))
+      (expressions)))
   (expression_statement
     (macro_invocation
       (scoped_identifier
         (scoped_identifier
           (identifier)
           (identifier))
-        (identifier)))))
+        (identifier))
+      (token_tree))))
 
 ================================================================================
 Macro invocation - arbitrary tokens
@@ -60,30 +65,30 @@ a!($a $a:ident $($a);*);
       (identifier)
       (expressions
         (unary_expression
-          (identifier)))
-      (ERROR)))
+          (identifier))
+        (ERROR))))
   (expression_statement
     (macro_invocation
       (identifier)
       (expressions
         (reference_expression
-          (identifier)))
-      (ERROR)))
+          (identifier))
+        (ERROR))))
   (expression_statement
     (macro_invocation
       (identifier)
       (expressions
         (unary_expression
-          (identifier)))
-      (ERROR)))
+          (identifier))
+        (ERROR))))
   (expression_statement
     (macro_invocation
       (identifier)
       (expressions
         (binary_expression
           (identifier)
-          (identifier)))
-      (ERROR)))
+          (identifier))
+        (ERROR))))
   (expression_statement
     (macro_invocation
       (identifier)
@@ -158,8 +163,9 @@ ok! {
 (source_file
   (macro_invocation
     (identifier)
+    (token_tree
     (line_comment)
-    (block_comment)))
+    (block_comment))))
 
 ================================================================================
 Macro definition
@@ -310,3 +316,52 @@ let x = vec![
                 (field_identifier))
               (arguments
                 (identifier)))))))))
+
+================================================================================
+Macro invocation - arrow-separated pairs
+================================================================================
+
+foo! {
+    key => "value",
+    shorthand,
+    another_key => value(),
+}
+
+nested_arrow_separated_pairs! {
+    key => {
+        nested_key => nested_value,
+    },
+    shorthand,
+    another_key => value(),
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (macro_invocation
+    (identifier)
+    (arrow_separated_pairs
+      (arrow_separated_pair
+        (identifier)
+        (string_literal))
+      (identifier)
+      (arrow_separated_pair
+        (identifier)
+        (call_expression
+          (identifier)
+          (arguments)))))
+  (macro_invocation
+    (identifier)
+    (arrow_separated_pairs
+      (arrow_separated_pair
+        (identifier)
+        (arrow_separated_pairs
+          (arrow_separated_pair
+            (identifier)
+            (identifier))))
+      (identifier)
+      (arrow_separated_pair
+        (identifier)
+        (call_expression
+          (identifier)
+          (arguments))))))

--- a/corpus/macros.txt
+++ b/corpus/macros.txt
@@ -335,6 +335,41 @@ nested_arrow_separated_pairs! {
     another_key => value(),
 }
 
+list_of_arrow_separated_pairs_value! {
+    key => [{nested_key => nested_value}],
+}
+
+rule! {
+    name => "no-debugger",
+    languages => [Javascript],
+    messages => [
+        unexpected => "Unexpected 'debugger' statement.",
+    ],
+    listeners => [
+        r#"(
+          (debugger_statement) @c
+        )"# => |node, context| {
+            context.report(violation! {
+                node => node,
+                message_id => "unexpected",
+            });
+        },
+    ],
+}
+
+rule_tests! {
+    valid => [
+        "var test = { debugger: 1 }; test.debugger;"
+    ],
+    invalid => [
+        {
+            code => "if (foo) debugger",
+            output => None,
+            errors => [{ message_id => "unexpected", type => "debugger_statement" }]
+        }
+    ]
+}
+
 --------------------------------------------------------------------------------
 
 (source_file
@@ -364,4 +399,79 @@ nested_arrow_separated_pairs! {
         (identifier)
         (call_expression
           (identifier)
-          (arguments))))))
+          (arguments)))))
+  (macro_invocation
+    (identifier)
+    (arrow_separated_pairs
+      (arrow_separated_pair
+        (identifier)
+        (arrow_separated_pairs_list
+              (arrow_separated_pair
+                (identifier)
+                (identifier))))))
+      (macro_invocation
+        (identifier)
+        (arrow_separated_pairs
+          (arrow_separated_pair
+            (identifier)
+        (string_literal))
+      (arrow_separated_pair
+        (identifier)
+        (array_expression
+          (identifier)))
+      (arrow_separated_pair
+        (identifier)
+        (arrow_separated_pairs
+          (arrow_separated_pair
+            (identifier)
+            (string_literal))))
+      (arrow_separated_pair
+        (identifier)
+        (arrow_separated_pairs
+          (arrow_separated_pair
+            (raw_string_literal)
+            (closure_expression
+              (closure_parameters
+                (identifier)
+                (identifier))
+              (block
+                (expression_statement
+                  (call_expression
+                    (field_expression
+                      (identifier)
+                      (field_identifier))
+                    (arguments
+                      (macro_invocation
+                        (identifier)
+                        (arrow_separated_pairs
+                          (arrow_separated_pair
+                            (identifier)
+                            (identifier))
+                          (arrow_separated_pair
+                            (identifier)
+                            (string_literal))))))))))))))
+  (macro_invocation
+    (identifier)
+    (arrow_separated_pairs
+      (arrow_separated_pair
+        (identifier)
+        (array_expression
+          (string_literal)))
+      (arrow_separated_pair
+        (identifier)
+        (arrow_separated_pairs_list
+          (arrow_separated_pair
+            (identifier)
+            (string_literal))
+          (arrow_separated_pair
+            (identifier)
+            (identifier))
+          (arrow_separated_pair
+            (identifier)
+            (arrow_separated_pairs_list
+              (arrow_separated_pair
+                (identifier)
+                (string_literal))
+              (arrow_separated_pair
+                (identifier)
+                (string_literal)))))))))

--- a/corpus/macros.txt
+++ b/corpus/macros.txt
@@ -13,30 +13,25 @@ f::g::h!{};
 (source_file
   (expression_statement
     (macro_invocation
-      (identifier)
-      (macro_invocation_contents)))
+      (identifier)))
   (expression_statement
     (macro_invocation
-      (identifier)
-      (macro_invocation_contents)))
+      (identifier)))
   (expression_statement
     (macro_invocation
-      (identifier)
-      (macro_invocation_contents)))
+      (identifier)))
   (expression_statement
     (macro_invocation
       (scoped_identifier
         (identifier)
-        (identifier))
-      (macro_invocation_contents)))
+        (identifier))))
   (expression_statement
     (macro_invocation
       (scoped_identifier
         (scoped_identifier
           (identifier)
           (identifier))
-        (identifier))
-      (macro_invocation_contents))))
+        (identifier)))))
 
 ================================================================================
 Macro invocation - arbitrary tokens
@@ -63,106 +58,91 @@ a!($a $a:ident $($a);*);
   (expression_statement
     (macro_invocation
       (identifier)
-      (macro_invocation_contents
-        (binary_expression
-          (unary_expression
-            (identifier))
-          (MISSING identifier)))))
+      (expressions
+        (unary_expression
+          (identifier)))
+      (ERROR)))
   (expression_statement
     (macro_invocation
       (identifier)
-      (macro_invocation_contents
-        (binary_expression
-          (reference_expression
-            (identifier))
-          (MISSING identifier)))))
+      (expressions
+        (reference_expression
+          (identifier)))
+      (ERROR)))
   (expression_statement
     (macro_invocation
       (identifier)
-      (macro_invocation_contents
-        (binary_expression
-          (unary_expression
-            (identifier))
-          (MISSING identifier)))))
+      (expressions
+        (unary_expression
+          (identifier)))
+      (ERROR)))
   (expression_statement
     (macro_invocation
       (identifier)
-      (macro_invocation_contents
+      (expressions
         (binary_expression
           (identifier)
-          (identifier))
-        (ERROR))))
+          (identifier)))
+      (ERROR)))
   (expression_statement
     (macro_invocation
       (identifier)
-          (macro_invocation_contents
+          (expressions
             (range_expression
               (char_literal)
               (char_literal)))))
   (expression_statement
     (macro_invocation
       (identifier)
-      (macro_invocation_contents
+      (expressions
         (range_expression
           (char_literal)
           (char_literal)))))
   (macro_invocation
     (identifier)
-    (macro_invocation_contents
-      (ERROR
-        (loop_label
-          (identifier)))))
+    (token_tree
+      (identifier)))
   (expression_statement
     (macro_invocation
       (identifier)
-      (macro_invocation_contents
+      (expressions
         (identifier))))
   (expression_statement
     (macro_invocation
       (identifier)
-      (macro_invocation_contents
+      (expressions
         (identifier))))
   (expression_statement
     (macro_invocation
       (identifier)
-      (macro_invocation_contents
-        (ERROR))))
+      (token_tree)))
   (expression_statement
     (macro_invocation
       (identifier)
-      (macro_invocation_contents
-        (ERROR)
-        (unit_expression))))
+      (token_tree
+        (token_tree))))
   (expression_statement
     (macro_invocation
       (identifier)
-      (macro_invocation_contents
-        (ERROR)
-        (identifier)
-        (ERROR))))
+      (token_tree
+        (identifier))))
   (expression_statement
     (macro_invocation
       (identifier)
-      (macro_invocation_contents
-        (ERROR)
-        (block
-          (ERROR)
-          (parenthesized_expression
-            (array_expression
+      (token_tree
+        (token_tree
+          (token_tree
+            (token_tree
               (identifier)))))))
   (expression_statement
     (macro_invocation
       (identifier)
-      (macro_invocation_contents
-        (binary_expression
-          (call_expression
-            (metavariable)
-            (ERROR
-              (metavariable))
-            (arguments
-              (metavariable)))
-          (ERROR)
-          (MISSING identifier))))))
+      (token_tree
+        (ERROR
+          (metavariable)
+          (metavariable))
+        (token_tree
+          (identifier))))))
 
 ================================================================================
 Macro invocation with comments
@@ -178,9 +158,8 @@ ok! {
 (source_file
   (macro_invocation
     (identifier)
-    (macro_invocation_contents
-      (line_comment)
-      (block_comment))))
+    (line_comment)
+    (block_comment)))
 
 ================================================================================
 Macro definition
@@ -303,7 +282,7 @@ let x = vec![
   (expression_statement
     (macro_invocation
       (identifier)
-      (macro_invocation_contents
+      (expressions
         (call_expression
           (field_expression
             (identifier)
@@ -316,7 +295,7 @@ let x = vec![
     (identifier)
     (macro_invocation
       (identifier)
-      (macro_invocation_contents
+      (expressions
         (call_expression
           (identifier)
           (arguments
@@ -324,7 +303,7 @@ let x = vec![
             (identifier)))
         (macro_invocation
           (identifier)
-          (macro_invocation_contents
+          (expressions
             (call_expression
               (field_expression
                 (identifier)

--- a/corpus/macros.txt
+++ b/corpus/macros.txt
@@ -64,34 +64,34 @@ a!($a $a:ident $($a);*);
     (macro_invocation
       (identifier)
       (macro_invocation_contents
-	(binary_expression
-	  (unary_expression
-	    (identifier))
-	  (MISSING identifier)))))
+        (binary_expression
+          (unary_expression
+            (identifier))
+          (MISSING identifier)))))
   (expression_statement
     (macro_invocation
       (identifier)
       (macro_invocation_contents
-	(binary_expression
-	  (reference_expression
-	    (identifier))
-	  (MISSING identifier)))))
+        (binary_expression
+          (reference_expression
+            (identifier))
+          (MISSING identifier)))))
   (expression_statement
     (macro_invocation
       (identifier)
       (macro_invocation_contents
-	(binary_expression
-	  (unary_expression
-	    (identifier))
-	  (MISSING identifier)))))
+        (binary_expression
+          (unary_expression
+            (identifier))
+          (MISSING identifier)))))
   (expression_statement
     (macro_invocation
       (identifier)
       (macro_invocation_contents
-	(binary_expression
-	  (identifier)
-	  (identifier))
-	(ERROR))))
+        (binary_expression
+          (identifier)
+          (identifier))
+        (ERROR))))
   (expression_statement
     (macro_invocation
       (identifier)
@@ -103,15 +103,15 @@ a!($a $a:ident $($a);*);
     (macro_invocation
       (identifier)
       (macro_invocation_contents
-	(range_expression
-	  (char_literal)
-	  (char_literal)))))
+        (range_expression
+          (char_literal)
+          (char_literal)))))
   (macro_invocation
     (identifier)
     (macro_invocation_contents
       (ERROR
-	(loop_label
-	  (identifier)))))
+        (loop_label
+          (identifier)))))
   (expression_statement
     (macro_invocation
       (identifier)
@@ -126,43 +126,43 @@ a!($a $a:ident $($a);*);
     (macro_invocation
       (identifier)
       (macro_invocation_contents
-	(ERROR))))
+        (ERROR))))
   (expression_statement
     (macro_invocation
       (identifier)
       (macro_invocation_contents
-	(ERROR)
-	(unit_expression))))
+        (ERROR)
+        (unit_expression))))
   (expression_statement
     (macro_invocation
       (identifier)
       (macro_invocation_contents
-	(ERROR)
-	(identifier)
-	(ERROR))))
+        (ERROR)
+        (identifier)
+        (ERROR))))
   (expression_statement
     (macro_invocation
       (identifier)
       (macro_invocation_contents
-	(ERROR)
-	(block
-	  (ERROR)
-	  (parenthesized_expression
-	    (array_expression
-	      (identifier)))))))
+        (ERROR)
+        (block
+          (ERROR)
+          (parenthesized_expression
+            (array_expression
+              (identifier)))))))
   (expression_statement
     (macro_invocation
       (identifier)
       (macro_invocation_contents
-	(binary_expression
-	  (call_expression
-	    (metavariable)
-	    (ERROR
-	      (metavariable))
-	    (arguments
-	      (metavariable)))
-	  (ERROR)
-	  (MISSING identifier))))))
+        (binary_expression
+          (call_expression
+            (metavariable)
+            (ERROR
+              (metavariable))
+            (arguments
+              (metavariable)))
+          (ERROR)
+          (MISSING identifier))))))
 
 ================================================================================
 Macro invocation with comments
@@ -286,3 +286,48 @@ macro_rules! zero_or_one {
       right: (token_tree
         (token_repetition
           (metavariable))))))
+
+================================================================================
+Macro invocation - expression "arguments"
+================================================================================
+
+println!(some.method(), a + b);
+let x = vec![
+  some_function(and, args),
+  nested!(here.they(are)),
+];
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (expression_statement
+    (macro_invocation
+      (identifier)
+      (macro_invocation_contents
+        (call_expression
+          (field_expression
+            (identifier)
+            (field_identifier))
+          (arguments))
+        (binary_expression
+          (identifier)
+          (identifier)))))
+  (let_declaration
+    (identifier)
+    (macro_invocation
+      (identifier)
+      (macro_invocation_contents
+        (call_expression
+          (identifier)
+          (arguments
+            (identifier)
+            (identifier)))
+        (macro_invocation
+          (identifier)
+          (macro_invocation_contents
+            (call_expression
+              (field_expression
+                (identifier)
+                (field_identifier))
+              (arguments
+                (identifier)))))))))

--- a/corpus/macros.txt
+++ b/corpus/macros.txt
@@ -14,21 +14,21 @@ f::g::h!{};
   (expression_statement
     (macro_invocation
       (identifier)
-      (token_tree)))
+      (macro_invocation_contents)))
   (expression_statement
     (macro_invocation
       (identifier)
-      (token_tree)))
+      (macro_invocation_contents)))
   (expression_statement
     (macro_invocation
       (identifier)
-      (token_tree)))
+      (macro_invocation_contents)))
   (expression_statement
     (macro_invocation
       (scoped_identifier
         (identifier)
         (identifier))
-      (token_tree)))
+      (macro_invocation_contents)))
   (expression_statement
     (macro_invocation
       (scoped_identifier
@@ -36,7 +36,7 @@ f::g::h!{};
           (identifier)
           (identifier))
         (identifier))
-      (token_tree))))
+      (macro_invocation_contents))))
 
 ================================================================================
 Macro invocation - arbitrary tokens
@@ -63,75 +63,106 @@ a!($a $a:ident $($a);*);
   (expression_statement
     (macro_invocation
       (identifier)
-      (token_tree
-        (identifier))))
+      (macro_invocation_contents
+	(binary_expression
+	  (unary_expression
+	    (identifier))
+	  (MISSING identifier)))))
   (expression_statement
     (macro_invocation
       (identifier)
-      (token_tree
-        (identifier))))
+      (macro_invocation_contents
+	(binary_expression
+	  (reference_expression
+	    (identifier))
+	  (MISSING identifier)))))
   (expression_statement
     (macro_invocation
       (identifier)
-      (token_tree
-        (identifier))))
+      (macro_invocation_contents
+	(binary_expression
+	  (unary_expression
+	    (identifier))
+	  (MISSING identifier)))))
   (expression_statement
     (macro_invocation
       (identifier)
-      (token_tree
-        (identifier)
-        (identifier))))
+      (macro_invocation_contents
+	(binary_expression
+	  (identifier)
+	  (identifier))
+	(ERROR))))
   (expression_statement
     (macro_invocation
       (identifier)
-      (token_tree
-        (char_literal)
-        (char_literal))))
+          (macro_invocation_contents
+            (range_expression
+              (char_literal)
+              (char_literal)))))
   (expression_statement
     (macro_invocation
       (identifier)
-      (token_tree
-        (char_literal)
-        (char_literal))))
+      (macro_invocation_contents
+	(range_expression
+	  (char_literal)
+	  (char_literal)))))
   (macro_invocation
     (identifier)
-    (token_tree
-      (identifier)))
+    (macro_invocation_contents
+      (ERROR
+	(loop_label
+	  (identifier)))))
   (expression_statement
     (macro_invocation
       (identifier)
-      (token_tree
+      (macro_invocation_contents
         (identifier))))
   (expression_statement
     (macro_invocation
       (identifier)
-      (token_tree
+      (macro_invocation_contents
         (identifier))))
   (expression_statement
     (macro_invocation
       (identifier)
-      (token_tree)))
+      (macro_invocation_contents
+	(ERROR))))
   (expression_statement
     (macro_invocation
       (identifier)
-      (token_tree (token_tree))))
+      (macro_invocation_contents
+	(ERROR)
+	(unit_expression))))
   (expression_statement
     (macro_invocation
       (identifier)
-      (token_tree (identifier))))
+      (macro_invocation_contents
+	(ERROR)
+	(identifier)
+	(ERROR))))
   (expression_statement
     (macro_invocation
       (identifier)
-      (token_tree (token_tree (token_tree (token_tree (identifier)))))))
+      (macro_invocation_contents
+	(ERROR)
+	(block
+	  (ERROR)
+	  (parenthesized_expression
+	    (array_expression
+	      (identifier)))))))
   (expression_statement
     (macro_invocation
       (identifier)
-      (token_tree
-        (identifier)
-        (identifier)
-        (identifier)
-        (token_tree
-          (identifier))))))
+      (macro_invocation_contents
+	(binary_expression
+	  (call_expression
+	    (metavariable)
+	    (ERROR
+	      (metavariable))
+	    (arguments
+	      (metavariable)))
+	  (ERROR)
+	  (MISSING identifier))))))
 
 ================================================================================
 Macro invocation with comments
@@ -147,7 +178,7 @@ ok! {
 (source_file
   (macro_invocation
     (identifier)
-    (token_tree
+    (macro_invocation_contents
       (line_comment)
       (block_comment))))
 

--- a/corpus/macros.txt
+++ b/corpus/macros.txt
@@ -342,10 +342,10 @@ list_of_arrow_separated_pairs_value! {
 rule! {
     name => "no-debugger",
     languages => [Javascript],
-    messages => [
+    messages => {
         unexpected => "Unexpected 'debugger' statement.",
-    ],
-    listeners => [
+    },
+    listeners => {
         r#"(
           (debugger_statement) @c
         )"# => |node, context| {
@@ -354,7 +354,7 @@ rule! {
                 message_id => "unexpected",
             });
         },
-    ],
+    },
 }
 
 rule_tests! {
@@ -368,6 +368,18 @@ rule_tests! {
             errors => [{ message_id => "unexpected", type => "debugger_statement" }]
         }
     ]
+}
+
+fn whee() {
+    RuleTester::run_with_from_file_run_context_instance_provider(
+        rule_tests! {
+            valid => [
+                "whee",
+                { code => "function f() { b; }", environment => { globals => { b => false } } },
+                { code => "function f() { b; }", environment => { globals => { b => false } } },
+            ],
+        }
+    )
 }
 
 --------------------------------------------------------------------------------
@@ -406,9 +418,10 @@ rule_tests! {
       (arrow_separated_pair
         (identifier)
         (arrow_separated_pairs_list
-              (arrow_separated_pair
-                (identifier)
-                (identifier))))))
+          (arrow_separated_pairs
+            (arrow_separated_pair
+              (identifier)
+              (identifier)))))))
       (macro_invocation
         (identifier)
         (arrow_separated_pairs
@@ -460,18 +473,63 @@ rule_tests! {
       (arrow_separated_pair
         (identifier)
         (arrow_separated_pairs_list
-          (arrow_separated_pair
+          (arrow_separated_pairs
+            (arrow_separated_pair
+              (identifier)
+              (string_literal))
+            (arrow_separated_pair
+              (identifier)
+              (identifier))
+            (arrow_separated_pair
+              (identifier)
+              (arrow_separated_pairs_list
+                (arrow_separated_pairs
+                  (arrow_separated_pair
+                    (identifier)
+                    (string_literal))
+                  (arrow_separated_pair
+                    (identifier)
+                    (string_literal)))
+                )))))))
+  (function_item
+    (identifier)
+    (parameters)
+    (block
+      (call_expression
+        (scoped_identifier
+          (identifier)
+          (identifier))
+        (arguments
+          (macro_invocation
             (identifier)
-            (string_literal))
-          (arrow_separated_pair
-            (identifier)
-            (identifier))
-          (arrow_separated_pair
-            (identifier)
-            (arrow_separated_pairs_list
+            (arrow_separated_pairs
               (arrow_separated_pair
                 (identifier)
-                (string_literal))
-              (arrow_separated_pair
-                (identifier)
-                (string_literal)))))))))
+                (arrow_separated_pairs_list
+                  (string_literal)
+                  (arrow_separated_pairs
+                    (arrow_separated_pair
+                      (identifier)
+                      (string_literal))
+                    (arrow_separated_pair
+                      (identifier)
+                      (arrow_separated_pairs
+                        (arrow_separated_pair
+                          (identifier)
+                          (arrow_separated_pairs
+                            (arrow_separated_pair
+                              (identifier)
+                              (boolean_literal)))))))
+                  (arrow_separated_pairs
+                    (arrow_separated_pair
+                      (identifier)
+                      (string_literal))
+                    (arrow_separated_pair
+                      (identifier)
+                      (arrow_separated_pairs
+                        (arrow_separated_pair
+                          (identifier)
+                          (arrow_separated_pairs
+                            (arrow_separated_pair
+                              (identifier)
+                              (boolean_literal))))))))))))))))

--- a/corpus/patterns.txt
+++ b/corpus/patterns.txt
@@ -376,10 +376,10 @@ if let x!() | y!() = () {}
         pattern: (or_pattern
           (macro_invocation
             macro: (identifier)
-            (token_tree))
+            (macro_invocation_contents))
           (macro_invocation
             macro: (identifier)
-            (token_tree)))
+            (macro_invocation_contents)))
         value: (unit_expression))
       consequence: (block)))
   (line_comment)
@@ -434,7 +434,7 @@ fn foo(x: i32) {
                 (identifier))
               value: (macro_invocation
                 macro: (identifier)
-                (token_tree
+                (macro_invocation_contents
                   (string_literal))))
             (match_arm
               pattern: (match_pattern)
@@ -462,7 +462,7 @@ fn foo(x: i32) {
                         (integer_literal))))))
               value: (macro_invocation
                 macro: (identifier)
-                (token_tree
+                (macro_invocation_contents
                   (string_literal))))
             (match_arm
               pattern: (match_pattern)

--- a/corpus/patterns.txt
+++ b/corpus/patterns.txt
@@ -375,9 +375,11 @@ if let x!() | y!() = () {}
       condition: (let_condition
         pattern: (or_pattern
           (macro_invocation
-            macro: (identifier))
+            macro: (identifier)
+            (expressions))
           (macro_invocation
-            macro: (identifier)))
+            macro: (identifier)
+            (expressions)))
         value: (unit_expression))
       consequence: (block)))
   (line_comment)

--- a/corpus/patterns.txt
+++ b/corpus/patterns.txt
@@ -375,11 +375,9 @@ if let x!() | y!() = () {}
       condition: (let_condition
         pattern: (or_pattern
           (macro_invocation
-            macro: (identifier)
-            (macro_invocation_contents))
+            macro: (identifier))
           (macro_invocation
-            macro: (identifier)
-            (macro_invocation_contents)))
+            macro: (identifier)))
         value: (unit_expression))
       consequence: (block)))
   (line_comment)
@@ -434,7 +432,7 @@ fn foo(x: i32) {
                 (identifier))
               value: (macro_invocation
                 macro: (identifier)
-                (macro_invocation_contents
+                (expressions
                   (string_literal))))
             (match_arm
               pattern: (match_pattern)
@@ -462,7 +460,7 @@ fn foo(x: i32) {
                         (integer_literal))))))
               value: (macro_invocation
                 macro: (identifier)
-                (macro_invocation_contents
+                (expressions
                   (string_literal))))
             (match_arm
               pattern: (match_pattern)

--- a/grammar.js
+++ b/grammar.js
@@ -111,7 +111,8 @@ module.exports = grammar({
     [$.array_expression, $.delim_token_tree],
     [$._expressions_inner, $._expression_or_arrow_separated_pair],
     [$.block, $._expression_or_arrow_separated_pair],
-    [$.array_expression, $._expression_or_arrow_separated_pair],
+    [$.array_expression, $._expression_or_arrow_separated_pairs_curly_braces],
+    [$._expression_or_arrow_separated_pairs_curly_braces, $.arrow_separated_pairs_list],
   ],
 
   word: $ => $.identifier,
@@ -1017,28 +1018,42 @@ module.exports = grammar({
     arrow_separated_pair: $ => seq(
       field('key', $._expression),
       '=>',
-      field('value', $._expression_or_arrow_separated_pairs),
+      field('value', $._expression_or_arrow_separated_pairs_curly_braces_or_arrow_separated_pairs_list),
     ),
 
-    _expression_or_arrow_separated_pairs: $ => choice(
+    _expression_or_arrow_separated_pairs_curly_braces_or_arrow_separated_pairs_list: $ => choice(
       prec.dynamic(4, $._expression),
       $.arrow_separated_pairs_list,
       alias(
-        choice(
-          $._arrow_separated_pairs_curly_braces,
-          $._arrow_separated_pairs_square_brackets,
-        ),
+        $._arrow_separated_pairs_curly_braces,
+        $.arrow_separated_pairs
+      ),
+    ),
+
+    _expression_or_arrow_separated_pairs_curly_braces: $ => choice(
+      prec.dynamic(4, $._expression),
+      alias(
+        $._arrow_separated_pairs_curly_braces,
         $.arrow_separated_pairs
       ),
     ),
 
     arrow_separated_pairs_list: $ => seq(
       '[',
-      $._arrow_separated_pairs_curly_braces,
+      repeat(
+        seq(
+          $._expression_or_arrow_separated_pairs_curly_braces,
+          ',',
+        ),
+      ),
+      alias(
+        $._arrow_separated_pairs_curly_braces,
+        $.arrow_separated_pairs
+      ),
       repeat(
         seq(
           ',',
-          $._arrow_separated_pairs_curly_braces,
+          $._expression_or_arrow_separated_pairs_curly_braces,
         ),
       ),
       optional(','),

--- a/grammar.js
+++ b/grammar.js
@@ -1015,9 +1015,9 @@ module.exports = grammar({
     ),
 
     arrow_separated_pair: $ => seq(
-      $._expression,
+      field('key', $._expression),
       '=>',
-      $._expression_or_arrow_separated_pairs,
+      field('value', $._expression_or_arrow_separated_pairs),
     ),
 
     _expression_or_arrow_separated_pairs: $ => choice(

--- a/grammar.js
+++ b/grammar.js
@@ -77,7 +77,7 @@ module.exports = grammar({
     [$.parameters, $._pattern],
     [$.parameters, $.tuple_struct_pattern],
     [$.type_parameters, $.for_lifetimes],
-    [$.parseable_macro_invocation_contents, $.delim_token_tree],
+    [$._parseable_macro_invocation_contents, $.delim_token_tree],
     [$._expression_except_range, $._non_delim_token],
     [$.loop_label, $._non_delim_token],
     [$.async_block, $._non_delim_token],
@@ -923,12 +923,12 @@ module.exports = grammar({
       )),
       '!',
       choice(
-        alias($.parseable_macro_invocation_contents, $.macro_invocation_contents),
+        $._parseable_macro_invocation_contents,
         alias($.delim_token_tree, $.token_tree),
       ),
     ),
 
-    parseable_macro_invocation_contents: $ => choice(
+    _parseable_macro_invocation_contents: $ => prec.dynamic(10, choice(
       seq(
         '[',
         optional(choice(
@@ -953,19 +953,27 @@ module.exports = grammar({
         )),
         '}'
       ),
-    ),
+    )),
 
     arrow_separated_pairs: $ => prec.dynamic(9, seq(
       $._expression_or_arrow_separated_pair,
-      ',',
-      sepBy(',', $._expression_or_arrow_separated_pair),
+      repeat(
+        seq(
+          ',',
+          $._expression_or_arrow_separated_pair,
+        )
+      ),
       optional(',')
     )),
 
     expressions: $ => prec.dynamic(10, seq(
       $._expression,
-      ',',
-      sepBy(',', $._expression),
+      repeat(
+        seq(
+          ',',
+          $._expression,
+        )
+      ),
       optional(',')
     )),
 
@@ -985,11 +993,11 @@ module.exports = grammar({
       $._expression,
     ),
 
-    delim_token_tree: $ => choice(
+    delim_token_tree: $ => prec.dynamic(0, choice(
       seq('(', repeat($._delim_tokens), ')'),
       seq('[', repeat($._delim_tokens), ']'),
       seq('{', repeat($._delim_tokens), '}')
-    ),
+    )),
 
     _delim_tokens: $ => choice(
       $._non_delim_token,

--- a/grammar.js
+++ b/grammar.js
@@ -889,7 +889,31 @@ module.exports = grammar({
         $._reserved_identifier,
       )),
       '!',
-      alias($.delim_token_tree, $.token_tree)
+      $.macro_invocation_contents,
+    ),
+
+    macro_invocation_contents: $ => choice(
+      $._macro_invocation_contents_parentheses,
+      $._macro_invocation_contents_square_brackets,
+      seq('{', repeat($._delim_tokens), '}'),
+    ),
+
+    _macro_invocation_contents_square_brackets: $ => seq(
+      '[',
+      seq(
+        sepBy(',', $._expression),
+        optional(',')
+      ),
+      ']'
+    ),
+
+    _macro_invocation_contents_parentheses: $ => seq(
+      '(',
+      seq(
+        sepBy(',', $._expression),
+        optional(',')
+      ),
+      ')'
     ),
 
     delim_token_tree: $ => choice(

--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -1,9 +1,0 @@
-((macro_invocation
-  (token_tree) @injection.content)
- (#set! injection.language "rust")
- (#set! injection.include-children))
-
-((macro_rule
-  (token_tree) @injection.content)
- (#set! injection.language "rust")
- (#set! injection.include-children))

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4904,6 +4904,139 @@
         "type": "CHOICE",
         "members": [
           {
+            "type": "SYMBOL",
+            "name": "arrow_separated_pairs"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "expressions"
+          }
+        ]
+      }
+    },
+    "arrow_separated_pairs": {
+      "type": "PREC_DYNAMIC",
+      "value": 10,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "["
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_arrow_separated_pairs_inner"
+              },
+              {
+                "type": "STRING",
+                "value": "]"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "("
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_arrow_separated_pairs_inner"
+              },
+              {
+                "type": "STRING",
+                "value": ")"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "{"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_arrow_separated_pairs_inner"
+              },
+              {
+                "type": "STRING",
+                "value": "}"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_arrow_separated_pairs_parens": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_arrow_separated_pairs_inner"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "_arrow_separated_pairs_braces_or_brackets": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "["
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_arrow_separated_pairs_inner"
+            },
+            {
+              "type": "STRING",
+              "value": "]"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "{"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_arrow_separated_pairs_inner"
+            },
+            {
+              "type": "STRING",
+              "value": "}"
+            }
+          ]
+        }
+      ]
+    },
+    "expressions": {
+      "type": "PREC_DYNAMIC",
+      "value": 10,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
             "type": "SEQ",
             "members": [
               {
@@ -4914,17 +5047,8 @@
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "arrow_separated_pairs"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "expressions"
-                      }
-                    ]
+                    "type": "SYMBOL",
+                    "name": "_expressions_inner"
                   },
                   {
                     "type": "BLANK"
@@ -4948,17 +5072,8 @@
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "arrow_separated_pairs"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "expressions"
-                      }
-                    ]
+                    "type": "SYMBOL",
+                    "name": "_expressions_inner"
                   },
                   {
                     "type": "BLANK"
@@ -4970,45 +5085,11 @@
                 "value": ")"
               }
             ]
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "{"
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "arrow_separated_pairs"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "expressions"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              },
-              {
-                "type": "STRING",
-                "value": "}"
-              }
-            ]
           }
         ]
       }
     },
-    "arrow_separated_pairs": {
+    "_arrow_separated_pairs_inner": {
       "type": "PREC_DYNAMIC",
       "value": 9,
       "content": {
@@ -5049,7 +5130,7 @@
         ]
       }
     },
-    "expressions": {
+    "_expressions_inner": {
       "type": "PREC_DYNAMIC",
       "value": 10,
       "content": {
@@ -5113,6 +5194,24 @@
         {
           "type": "STRING",
           "value": "=>"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expression_or_arrow_separated_pairs"
+        }
+      ]
+    },
+    "_expression_or_arrow_separated_pairs": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_arrow_separated_pairs_braces_or_brackets"
+          },
+          "named": true,
+          "value": "arrow_separated_pairs"
         },
         {
           "type": "SYMBOL",
@@ -8730,7 +8829,7 @@
       "for_lifetimes"
     ],
     [
-      "_parseable_macro_invocation_contents",
+      "expressions",
       "delim_token_tree"
     ],
     [
@@ -8860,7 +8959,15 @@
       "delim_token_tree"
     ],
     [
-      "expressions",
+      "_expressions_inner",
+      "_expression_or_arrow_separated_pair"
+    ],
+    [
+      "block",
+      "_expression_or_arrow_separated_pair"
+    ],
+    [
+      "array_expression",
       "_expression_or_arrow_separated_pair"
     ]
   ],

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4878,13 +4878,167 @@
           "value": "!"
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "delim_token_tree"
-          },
-          "named": true,
-          "value": "token_tree"
+          "type": "SYMBOL",
+          "name": "macro_invocation_contents"
+        }
+      ]
+    },
+    "macro_invocation_contents": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_macro_invocation_contents_parentheses"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_macro_invocation_contents_square_brackets"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "{"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_delim_tokens"
+              }
+            },
+            {
+              "type": "STRING",
+              "value": "}"
+            }
+          ]
+        }
+      ]
+    },
+    "_macro_invocation_contents_square_brackets": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_expression"
+                    },
+                    {
+                      "type": "REPEAT",
+                      "content": {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": ","
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "_expression"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ","
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
+    "_macro_invocation_contents_parentheses": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_expression"
+                    },
+                    {
+                      "type": "REPEAT",
+                      "content": {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": ","
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "_expression"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ","
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4878,21 +4878,100 @@
           "value": "!"
         },
         {
-          "type": "SYMBOL",
-          "name": "macro_invocation_contents"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "parseable_macro_invocation_contents"
+              },
+              "named": true,
+              "value": "macro_invocation_contents"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "delim_token_tree"
+              },
+              "named": true,
+              "value": "token_tree"
+            }
+          ]
         }
       ]
     },
-    "macro_invocation_contents": {
+    "parseable_macro_invocation_contents": {
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "_macro_invocation_contents_parentheses"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "["
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "arrow_separated_pairs"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "expressions"
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": "]"
+            }
+          ]
         },
         {
-          "type": "SYMBOL",
-          "name": "_macro_invocation_contents_square_brackets"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "("
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "arrow_separated_pairs"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "expressions"
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": ")"
+            }
+          ]
         },
         {
           "type": "SEQ",
@@ -4902,11 +4981,25 @@
               "value": "{"
             },
             {
-              "type": "REPEAT",
-              "content": {
-                "type": "SYMBOL",
-                "name": "_delim_tokens"
-              }
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "arrow_separated_pairs"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "expressions"
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             },
             {
               "type": "STRING",
@@ -4916,129 +5009,157 @@
         }
       ]
     },
-    "_macro_invocation_contents_square_brackets": {
-      "type": "SEQ",
+    "arrow_separated_pairs": {
+      "type": "PREC_DYNAMIC",
+      "value": 9,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_expression_or_arrow_separated_pair"
+          },
+          {
+            "type": "STRING",
+            "value": ","
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_expression_or_arrow_separated_pair"
+                  },
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": ","
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "_expression_or_arrow_separated_pair"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ","
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "expressions": {
+      "type": "PREC_DYNAMIC",
+      "value": 10,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_expression"
+          },
+          {
+            "type": "STRING",
+            "value": ","
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_expression"
+                  },
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": ","
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "_expression"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ","
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_expression_or_arrow_separated_pair": {
+      "type": "CHOICE",
       "members": [
         {
-          "type": "STRING",
-          "value": "["
+          "type": "SYMBOL",
+          "name": "arrow_separated_pair"
         },
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_expression"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": ","
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "_expression"
-                          }
-                        ]
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": ","
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "]"
+          "type": "SYMBOL",
+          "name": "_expression"
         }
       ]
     },
-    "_macro_invocation_contents_parentheses": {
+    "arrow_separated_pair": {
       "type": "SEQ",
       "members": [
         {
-          "type": "STRING",
-          "value": "("
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_expression"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": ","
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "_expression"
-                          }
-                        ]
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": ","
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_expression"
         },
         {
           "type": "STRING",
-          "value": ")"
+          "value": "=>"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expression"
         }
       ]
     },
@@ -8646,6 +8767,140 @@
     [
       "type_parameters",
       "for_lifetimes"
+    ],
+    [
+      "parseable_macro_invocation_contents",
+      "delim_token_tree"
+    ],
+    [
+      "_expression_except_range",
+      "_non_delim_token"
+    ],
+    [
+      "loop_label",
+      "_non_delim_token"
+    ],
+    [
+      "async_block",
+      "_non_delim_token"
+    ],
+    [
+      "break_expression",
+      "_non_delim_token"
+    ],
+    [
+      "const_block",
+      "_non_delim_token"
+    ],
+    [
+      "continue_expression",
+      "_non_delim_token"
+    ],
+    [
+      "for_expression",
+      "_non_delim_token"
+    ],
+    [
+      "if_expression",
+      "_non_delim_token"
+    ],
+    [
+      "loop_expression",
+      "_non_delim_token"
+    ],
+    [
+      "match_expression",
+      "_non_delim_token"
+    ],
+    [
+      "return_expression",
+      "_non_delim_token"
+    ],
+    [
+      "unsafe_block",
+      "_non_delim_token"
+    ],
+    [
+      "while_expression",
+      "_non_delim_token"
+    ],
+    [
+      "struct_expression",
+      "_non_delim_token"
+    ],
+    [
+      "unit_expression",
+      "delim_token_tree"
+    ],
+    [
+      "block",
+      "delim_token_tree"
+    ],
+    [
+      "function_modifiers",
+      "_non_delim_token"
+    ],
+    [
+      "const_item",
+      "_non_delim_token"
+    ],
+    [
+      "enum_item",
+      "_non_delim_token"
+    ],
+    [
+      "function_item",
+      "function_signature_item",
+      "_non_delim_token"
+    ],
+    [
+      "impl_item",
+      "_non_delim_token"
+    ],
+    [
+      "let_declaration",
+      "_non_delim_token"
+    ],
+    [
+      "mod_item",
+      "_non_delim_token"
+    ],
+    [
+      "visibility_modifier",
+      "_non_delim_token"
+    ],
+    [
+      "static_item",
+      "_non_delim_token"
+    ],
+    [
+      "struct_item",
+      "_non_delim_token"
+    ],
+    [
+      "trait_item",
+      "_non_delim_token"
+    ],
+    [
+      "type_item",
+      "associated_type",
+      "_non_delim_token"
+    ],
+    [
+      "union_item",
+      "_non_delim_token"
+    ],
+    [
+      "use_declaration",
+      "_non_delim_token"
+    ],
+    [
+      "array_expression",
+      "delim_token_tree"
+    ],
+    [
+      "expressions",
+      "_expression_or_arrow_separated_pair"
     ]
   ],
   "precedences": [],

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4881,13 +4881,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "ALIAS",
-              "content": {
-                "type": "SYMBOL",
-                "name": "parseable_macro_invocation_contents"
-              },
-              "named": true,
-              "value": "macro_invocation_contents"
+              "type": "SYMBOL",
+              "name": "_parseable_macro_invocation_contents"
             },
             {
               "type": "ALIAS",
@@ -4902,112 +4897,116 @@
         }
       ]
     },
-    "parseable_macro_invocation_contents": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "["
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "arrow_separated_pairs"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "expressions"
-                    }
-                  ]
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "STRING",
-              "value": "]"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "("
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "arrow_separated_pairs"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "expressions"
-                    }
-                  ]
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "STRING",
-              "value": ")"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "{"
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "arrow_separated_pairs"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "expressions"
-                    }
-                  ]
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "STRING",
-              "value": "}"
-            }
-          ]
-        }
-      ]
+    "_parseable_macro_invocation_contents": {
+      "type": "PREC_DYNAMIC",
+      "value": 10,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "["
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "arrow_separated_pairs"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "expressions"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              },
+              {
+                "type": "STRING",
+                "value": "]"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "("
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "arrow_separated_pairs"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "expressions"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              },
+              {
+                "type": "STRING",
+                "value": ")"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "{"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "arrow_separated_pairs"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "expressions"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              },
+              {
+                "type": "STRING",
+                "value": "}"
+              }
+            ]
+          }
+        ]
+      }
     },
     "arrow_separated_pairs": {
       "type": "PREC_DYNAMIC",
@@ -5020,41 +5019,20 @@
             "name": "_expression_or_arrow_separated_pair"
           },
           {
-            "type": "STRING",
-            "value": ","
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_expression_or_arrow_separated_pair"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ","
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "_expression_or_arrow_separated_pair"
-                        }
-                      ]
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
+            "type": "REPEAT",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ","
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_expression_or_arrow_separated_pair"
+                }
+              ]
+            }
           },
           {
             "type": "CHOICE",
@@ -5082,41 +5060,20 @@
             "name": "_expression"
           },
           {
-            "type": "STRING",
-            "value": ","
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_expression"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ","
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "_expression"
-                        }
-                      ]
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
+            "type": "REPEAT",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ","
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              ]
+            }
           },
           {
             "type": "CHOICE",
@@ -5164,69 +5121,73 @@
       ]
     },
     "delim_token_tree": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "("
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SYMBOL",
-                "name": "_delim_tokens"
+      "type": "PREC_DYNAMIC",
+      "value": 0,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "("
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_delim_tokens"
+                }
+              },
+              {
+                "type": "STRING",
+                "value": ")"
               }
-            },
-            {
-              "type": "STRING",
-              "value": ")"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "["
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SYMBOL",
-                "name": "_delim_tokens"
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "["
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_delim_tokens"
+                }
+              },
+              {
+                "type": "STRING",
+                "value": "]"
               }
-            },
-            {
-              "type": "STRING",
-              "value": "]"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "{"
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SYMBOL",
-                "name": "_delim_tokens"
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "{"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_delim_tokens"
+                }
+              },
+              {
+                "type": "STRING",
+                "value": "}"
               }
-            },
-            {
-              "type": "STRING",
-              "value": "}"
-            }
-          ]
-        }
-      ]
+            ]
+          }
+        ]
+      }
     },
     "_delim_tokens": {
       "type": "CHOICE",
@@ -8769,7 +8730,7 @@
       "for_lifetimes"
     ],
     [
-      "parseable_macro_invocation_contents",
+      "_parseable_macro_invocation_contents",
       "delim_token_tree"
     ],
     [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5166,12 +5166,12 @@
           "name": "value",
           "content": {
             "type": "SYMBOL",
-            "name": "_expression_or_arrow_separated_pairs"
+            "name": "_expression_or_arrow_separated_pairs_curly_braces_or_arrow_separated_pairs_list"
           }
         }
       ]
     },
-    "_expression_or_arrow_separated_pairs": {
+    "_expression_or_arrow_separated_pairs_curly_braces_or_arrow_separated_pairs_list": {
       "type": "CHOICE",
       "members": [
         {
@@ -5189,17 +5189,30 @@
         {
           "type": "ALIAS",
           "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arrow_separated_pairs_curly_braces"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_arrow_separated_pairs_square_brackets"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arrow_separated_pairs_curly_braces"
+          },
+          "named": true,
+          "value": "arrow_separated_pairs"
+        }
+      ]
+    },
+    "_expression_or_arrow_separated_pairs_curly_braces": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "PREC_DYNAMIC",
+          "value": 4,
+          "content": {
+            "type": "SYMBOL",
+            "name": "_expression"
+          }
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_arrow_separated_pairs_curly_braces"
           },
           "named": true,
           "value": "arrow_separated_pairs"
@@ -5214,8 +5227,29 @@
           "value": "["
         },
         {
-          "type": "SYMBOL",
-          "name": "_arrow_separated_pairs_curly_braces"
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_expression_or_arrow_separated_pairs_curly_braces"
+              },
+              {
+                "type": "STRING",
+                "value": ","
+              }
+            ]
+          }
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_arrow_separated_pairs_curly_braces"
+          },
+          "named": true,
+          "value": "arrow_separated_pairs"
         },
         {
           "type": "REPEAT",
@@ -5228,7 +5262,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "_arrow_separated_pairs_curly_braces"
+                "name": "_expression_or_arrow_separated_pairs_curly_braces"
               }
             ]
           }
@@ -8996,7 +9030,11 @@
     ],
     [
       "array_expression",
-      "_expression_or_arrow_separated_pair"
+      "_expression_or_arrow_separated_pairs_curly_braces"
+    ],
+    [
+      "_expression_or_arrow_separated_pairs_curly_braces",
+      "arrow_separated_pairs_list"
     ]
   ],
   "precedences": [],

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5150,16 +5150,24 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "_expression"
+          "type": "FIELD",
+          "name": "key",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_expression"
+          }
         },
         {
           "type": "STRING",
           "value": "=>"
         },
         {
-          "type": "SYMBOL",
-          "name": "_expression_or_arrow_separated_pairs"
+          "type": "FIELD",
+          "name": "value",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_expression_or_arrow_separated_pairs"
+          }
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4881,8 +4881,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_parseable_macro_invocation_contents"
+              "type": "PREC_DYNAMIC",
+              "value": 1,
+              "content": {
+                "type": "SYMBOL",
+                "name": "_parseable_macro_invocation_contents"
+              }
             },
             {
               "type": "ALIAS",
@@ -4898,81 +4902,38 @@
       ]
     },
     "_parseable_macro_invocation_contents": {
-      "type": "PREC_DYNAMIC",
-      "value": 10,
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "arrow_separated_pairs"
-          },
-          {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "arrow_separated_pairs"
+        },
+        {
+          "type": "PREC_DYNAMIC",
+          "value": 1,
+          "content": {
             "type": "SYMBOL",
             "name": "expressions"
           }
-        ]
-      }
+        }
+      ]
     },
     "arrow_separated_pairs": {
-      "type": "PREC_DYNAMIC",
-      "value": 10,
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "["
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_arrow_separated_pairs_inner"
-              },
-              {
-                "type": "STRING",
-                "value": "]"
-              }
-            ]
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "("
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_arrow_separated_pairs_inner"
-              },
-              {
-                "type": "STRING",
-                "value": ")"
-              }
-            ]
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "{"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_arrow_separated_pairs_inner"
-              },
-              {
-                "type": "STRING",
-                "value": "}"
-              }
-            ]
-          }
-        ]
-      }
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_arrow_separated_pairs_parens"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_arrow_separated_pairs_curly_braces"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_arrow_separated_pairs_square_brackets"
+        }
+      ]
     },
     "_arrow_separated_pairs_parens": {
       "type": "SEQ",
@@ -4991,26 +4952,9 @@
         }
       ]
     },
-    "_arrow_separated_pairs_braces_or_brackets": {
+    "_arrow_separated_pairs_curly_braces": {
       "type": "CHOICE",
       "members": [
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "["
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_arrow_separated_pairs_inner"
-            },
-            {
-              "type": "STRING",
-              "value": "]"
-            }
-          ]
-        },
         {
           "type": "SEQ",
           "members": [
@@ -5030,68 +4974,86 @@
         }
       ]
     },
+    "_arrow_separated_pairs_square_brackets": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "["
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_arrow_separated_pairs_inner"
+            },
+            {
+              "type": "STRING",
+              "value": "]"
+            }
+          ]
+        }
+      ]
+    },
     "expressions": {
-      "type": "PREC_DYNAMIC",
-      "value": 10,
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "["
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_expressions_inner"
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              },
-              {
-                "type": "STRING",
-                "value": "]"
-              }
-            ]
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "("
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_expressions_inner"
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              },
-              {
-                "type": "STRING",
-                "value": ")"
-              }
-            ]
-          }
-        ]
-      }
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "["
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_expressions_inner"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": "]"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "("
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_expressions_inner"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": ")"
+            }
+          ]
+        }
+      ]
     },
     "_arrow_separated_pairs_inner": {
       "type": "PREC_DYNAMIC",
-      "value": 9,
+      "value": 1,
       "content": {
         "type": "SEQ",
         "members": [
@@ -5132,7 +5094,7 @@
     },
     "_expressions_inner": {
       "type": "PREC_DYNAMIC",
-      "value": 10,
+      "value": 2,
       "content": {
         "type": "SEQ",
         "members": [
@@ -5205,88 +5167,146 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "ALIAS",
+          "type": "PREC_DYNAMIC",
+          "value": 4,
           "content": {
             "type": "SYMBOL",
-            "name": "_arrow_separated_pairs_braces_or_brackets"
-          },
-          "named": true,
-          "value": "arrow_separated_pairs"
+            "name": "_expression"
+          }
         },
         {
           "type": "SYMBOL",
-          "name": "_expression"
+          "name": "arrow_separated_pairs_list"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_arrow_separated_pairs_curly_braces"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_arrow_separated_pairs_square_brackets"
+              }
+            ]
+          },
+          "named": true,
+          "value": "arrow_separated_pairs"
+        }
+      ]
+    },
+    "arrow_separated_pairs_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_arrow_separated_pairs_curly_braces"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ","
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_arrow_separated_pairs_curly_braces"
+              }
+            ]
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": ","
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "]"
         }
       ]
     },
     "delim_token_tree": {
-      "type": "PREC_DYNAMIC",
-      "value": 0,
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "("
-              },
-              {
-                "type": "REPEAT",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_delim_tokens"
-                }
-              },
-              {
-                "type": "STRING",
-                "value": ")"
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "("
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_delim_tokens"
               }
-            ]
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "["
-              },
-              {
-                "type": "REPEAT",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_delim_tokens"
-                }
-              },
-              {
-                "type": "STRING",
-                "value": "]"
+            },
+            {
+              "type": "STRING",
+              "value": ")"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "["
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_delim_tokens"
               }
-            ]
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "{"
-              },
-              {
-                "type": "REPEAT",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_delim_tokens"
-                }
-              },
-              {
-                "type": "STRING",
-                "value": "}"
+            },
+            {
+              "type": "STRING",
+              "value": "]"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "{"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_delim_tokens"
               }
-            ]
-          }
-        ]
-      }
+            },
+            {
+              "type": "STRING",
+              "value": "}"
+            }
+          ]
+        }
+      ]
     },
     "_delim_tokens": {
       "type": "CHOICE",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2641,25 +2641,6 @@
     },
     "children": {
       "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "macro_invocation_contents",
-          "named": true
-        },
-        {
-          "type": "token_tree",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "macro_invocation_contents",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
       "required": false,
       "types": [
         {
@@ -2668,6 +2649,10 @@
         },
         {
           "type": "expressions",
+          "named": true
+        },
+        {
+          "type": "token_tree",
           "named": true
         }
       ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -617,14 +617,14 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "_expression",
           "named": true
         },
         {
-          "type": "arrow_separated_pair",
+          "type": "arrow_separated_pairs",
           "named": true
         }
       ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2595,6 +2595,41 @@
       "required": true,
       "types": [
         {
+          "type": "macro_invocation_contents",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "macro_invocation_contents",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "_expression",
+          "named": true
+        },
+        {
+          "type": "crate",
+          "named": true
+        },
+        {
+          "type": "mutable_specifier",
+          "named": true
+        },
+        {
+          "type": "primitive_type",
+          "named": true
+        },
+        {
+          "type": "super",
+          "named": true
+        },
+        {
           "type": "token_tree",
           "named": true
         }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -569,6 +569,10 @@
         {
           "type": "_expression",
           "named": true
+        },
+        {
+          "type": "arrow_separated_pairs",
+          "named": true
         }
       ]
     }
@@ -579,7 +583,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "_expression",
@@ -1616,7 +1620,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "_expression",
@@ -2641,7 +2645,7 @@
     },
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "arrow_separated_pairs",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -573,12 +573,35 @@
         {
           "type": "arrow_separated_pairs",
           "named": true
+        },
+        {
+          "type": "arrow_separated_pairs_list",
+          "named": true
         }
       ]
     }
   },
   {
     "type": "arrow_separated_pairs",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "_expression",
+          "named": true
+        },
+        {
+          "type": "arrow_separated_pair",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "arrow_separated_pairs_list",
     "named": true,
     "fields": {},
     "children": {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -561,24 +561,35 @@
   {
     "type": "arrow_separated_pair",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "_expression",
-          "named": true
-        },
-        {
-          "type": "arrow_separated_pairs",
-          "named": true
-        },
-        {
-          "type": "arrow_separated_pairs_list",
-          "named": true
-        }
-      ]
+    "fields": {
+      "key": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "_expression",
+            "named": true
+          }
+        ]
+      },
+      "value": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "_expression",
+            "named": true
+          },
+          {
+            "type": "arrow_separated_pairs",
+            "named": true
+          },
+          {
+            "type": "arrow_separated_pairs_list",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -559,6 +559,40 @@
     }
   },
   {
+    "type": "arrow_separated_pair",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "arrow_separated_pairs",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "_expression",
+          "named": true
+        },
+        {
+          "type": "arrow_separated_pair",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "assignment_expression",
     "named": true,
     "fields": {
@@ -1567,6 +1601,21 @@
     "fields": {},
     "children": {
       "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "expressions",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
       "required": true,
       "types": [
         {
@@ -2597,6 +2646,10 @@
         {
           "type": "macro_invocation_contents",
           "named": true
+        },
+        {
+          "type": "token_tree",
+          "named": true
         }
       ]
     }
@@ -2606,31 +2659,15 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": false,
       "types": [
         {
-          "type": "_expression",
+          "type": "arrow_separated_pairs",
           "named": true
         },
         {
-          "type": "crate",
-          "named": true
-        },
-        {
-          "type": "mutable_specifier",
-          "named": true
-        },
-        {
-          "type": "primitive_type",
-          "named": true
-        },
-        {
-          "type": "super",
-          "named": true
-        },
-        {
-          "type": "token_tree",
+          "type": "expressions",
           "named": true
         }
       ]


### PR DESCRIPTION
In this PR:
- adjust Rust grammar to expose contents of macro invocations (eg `println!(...)`, `vec![...]`) as "actual Rust AST nodes"

To test:
If set up for local development, you can run `tree-sitter test` and tests should pass and if you eg run `tree-sitter parse` against a file with some "structured expression arguments" to macro invocations eg `println!(some.method_call())` then you should see the eg `call_expression` tree-sitter AST nodes nested under a `macro_invocation_contents` AST node